### PR TITLE
#160045670 use dot env files to load Environmental variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+FLASK_ENV=development
+FLASK_APP=run.py
+DB_NAME=stackoverflow
+APP_KEY="Some API random key"
+TEST_DB_NAME=testing_stackoverflow

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /__pycache__
 __pycache__/
 .pytest_cache/
+*.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,10 @@ deploy:
   provider: heroku
   api_key:
     secure: Eav/qEQN89dyvqBKam746FbeRAo8GQtfjicoxjev482DFHowK3BvieKiHlUzdMdZiAr38uZb2KYD39KdDV/xTMGKENL+/4ADWVywRl4EaNJd+5ufjx8zhQjElZJMpV1mnHCbVLmbE4v3XU65SbibpyjeDvcUMNKYDSjxuRAv0nsWdR/YFYt0s0hTALAGRb/q369+gWtCaX87UGxwUuMmg0uhl9Ke3ktdTStaytymNt4cToQ5V0LQopNs/lQgSb9ZQgLxhBmtjAqKVmyGQzXZc++Poyexeq1bdMA/AcuyyknmeTbYfIW9UNxUxBwCUCVQ/3qMDS4fyNAOYKlERt0agdxlOmQayEEkSgmrd6+iSTR1foena2pHcS2q6Pl9CncIygHezm/9uYPIhg1HmziNQR+peH4q278gSlDh9Z0TOT7NaBIzreTg8ZzrdmolhXEiLFLsX36OGz6HOjec4n8VOcvkDbEb0oQwU3GYTfAMpEk+XgsswSpii5pW75fmklJrr3dHvifekDpcHDhNMU9QCcU+R2LkkZpG3+8g9qsGyG7yoqveIbVO96M8gjvhORRDh7dt+/4GQ9UOkVSifa4q2rUxyXDCLXFlcvI5SwpUgcinvIjCpWRVQBEpeRMbg1Y/KugEtYMtp9AG02+ITLttTUkzmXGiqYKpgsTpgHZKpCM=
-  app: 
+  app:
     staging: andela-stackoverflow
     release-v1.0.0: andela-stackoverflow-v1
-
-  
+env:
+  global:
+    - APP_KEY="Some API key"
+    - TEST_DB_NAME=testing_stackoverflow

--- a/api/config.py
+++ b/api/config.py
@@ -1,6 +1,7 @@
+import sys
 from os import getenv, path
 from dotenv import load_dotenv
-import sys
+
 
 # load environment variables
 env_path = path.abspath(".env")

--- a/api/config.py
+++ b/api/config.py
@@ -1,13 +1,27 @@
+from os import getenv, path
+from dotenv import load_dotenv
+import sys
+
+# load environment variables
+env_path = path.abspath(".env")
+
+if not path.exists(env_path):  # pragma: no cover
+    print("A .env configuration file was not found in your root project")
+    sys.exit(0)
+
+load_dotenv(verbose=True, dotenv_path=env_path)
+
+
 class Configuration:
     """Common configuration for all environments """
-    DB_NAME = "stackoverflow"
-    SECRET = "J0NJxenTRjjupTknRQsKFbka5JoIxgmAKQcMfl1vkB8"
+    DB_NAME = getenv("DB_NAME")
+    SECRET = getenv("APP_KEY")
 
 
 class TestConfiguration(Configuration):
     """Configuration for the test environment"""
     TESTING = True
-    DB_NAME = "testing_stackoverflow"
+    DB_NAME = getenv("TEST_DB_NAME")
 
 
 class DevelopmentConfiguration(Configuration):

--- a/api/config.py
+++ b/api/config.py
@@ -1,14 +1,9 @@
-import sys
 from os import getenv, path
 from dotenv import load_dotenv
 
 
 # load environment variables
 env_path = path.abspath(".env")
-
-if not path.exists(env_path):  # pragma: no cover
-    print("A .env configuration file was not found in your root project")
-    sys.exit(0)
 
 load_dotenv(verbose=True, dotenv_path=env_path)
 

--- a/api/core/JSONEncoder.py
+++ b/api/core/JSONEncoder.py
@@ -5,7 +5,7 @@ from api.core.models.collections import ModelCollection
 
 class JSONEncoder(BaseJSONEncoder):
     def default(self, o):
-        if isinstance(o, Model) or isinstance(o, ModelCollection):
+        if isinstance(o, (Model, ModelCollection)):
             return o.to_json()
         if isinstance(o, bytes):
             return o.decode("UTF-8")

--- a/api/core/JSONEncoder.py
+++ b/api/core/JSONEncoder.py
@@ -1,13 +1,12 @@
 from flask.json import JSONEncoder as BaseJSONEncoder
 from api.core.models import Model
 from api.core.models.collections import ModelCollection
-from datetime import datetime
 
 
 class JSONEncoder(BaseJSONEncoder):
     def default(self, o):
         if isinstance(o, Model) or isinstance(o, ModelCollection):
             return o.to_json()
-        if isinstance(o, datetime):
-            return o.strftime('%Y-%m-%d %H:%M:%S')
-        return JSONEncoder.default(self, o)  # pragma: no cover
+        if isinstance(o, bytes):
+            return o.decode("UTF-8")
+        return BaseJSONEncoder.default(self, o)

--- a/api/core/JWT.py
+++ b/api/core/JWT.py
@@ -15,8 +15,8 @@ class JWT:
     def generate_token(self, subject):
         return jwt.encode(
             {'subject': subject, 'exp': self.expires},
-            **self._make_options(),
-        ).decode("UTF-8")
+            **self._make_options()
+        )
 
     def get_subject_from_headers(self):
         token = self.get_token_from_header()

--- a/api/core/Utils.py
+++ b/api/core/Utils.py
@@ -13,9 +13,6 @@ class Fluent:
     def update(self, attributes):
         self.attributes.update(attributes)
 
-    def values(self):
-        return self.attributes.values()
-
     def set_attributes(self, attributes):
         object.__setattr__(self, "attributes", attributes)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ pylint==2.1.1
 pytest==3.7.1
 pytest-cov==2.5.1
 python-coveralls==2.9.1
+python-dotenv==0.9.1
 PyYAML==3.13
 requests==2.19.1
 six==1.11.0


### PR DESCRIPTION
#### What does this PR do?
Currently, all configuration values are placed in a single config file including those that should be kept secret e.g the Database Variables

This PR gives an opportunity to put the secret variables in a private `.env` whose values can be exported to environmental variables using [python-dotenv](https://github.com/theskumar/python-dotenv).

#### How should this be manually tested?
Since the variables  located in the `.env` are secret variables, `.env` is blacklisted from `VCS`, however an example of how the `.env`  file looks like is given, just rename `.env.example` to `.env` and replace the dummy values with actual values

- Refer to README.md for setup instructions
#### What are the relevant pivotal tracker stories?
[#160045670](https://www.pivotaltracker.com/story/show/160045670)