### PR TITLE
 #160057897 A user should only delete his question

### DIFF
--- a/api/app/controllers/QuestionsController.py
+++ b/api/app/controllers/QuestionsController.py
@@ -1,5 +1,5 @@
 from flask import jsonify, request
-from api.app.models import Question
+from api.app.models import Question, User
 from .BaseController import ProtectedController
 
 validation_rules = {
@@ -37,5 +37,10 @@ class QuestionsController(ProtectedController):
 
     @classmethod
     def destroy(cls, id):
-        Question.find_or_fail(id).delete()
+        question = Question.find_or_fail(id)
+        if not User.can_delete_quesiton(question):
+            return jsonify(dict(
+                error="Access denied  to delete question"
+            )), 401
+        question.delete()
         return jsonify(dict(message="Resource was removed successfully"))

--- a/api/app/databases/migrations/Questions.py
+++ b/api/app/databases/migrations/Questions.py
@@ -6,6 +6,7 @@ class QuestionsTable(Migration):
     def up(self):
         table = TableSchema.create("questions")
         table.increments("id")
+        table.integer("user_id")
         table.string("title", 100)
         table.text("description")
         table.timestamps()

--- a/api/app/models/Question.py
+++ b/api/app/models/Question.py
@@ -1,5 +1,6 @@
 from api.core.models import Model
 from .Answer import Answer
+from .User import Auth
 
 
 class Question(Model):
@@ -9,3 +10,6 @@ class Question(Model):
 
     def answers(self):
         return self.has_many(Answer)
+
+    def _creating(self):
+        self.attributes["user_id"] = Auth.id()

--- a/api/app/models/User.py
+++ b/api/app/models/User.py
@@ -18,8 +18,7 @@ class Auth:
         return self.jwt.generate_token(user.attributes["email"])
 
     def is_authenticated(self):
-        if not self.user:
-            self.user = self.get_user(self.jwt.get_subject_from_headers())
+        Auth.user = self.get_user(self.jwt.get_subject_from_headers())
         return True
 
     def get_user(self, email):
@@ -27,6 +26,10 @@ class Auth:
         if not data:
             return abort(401, "Email Address not found")
         return self.UserModel(data)
+
+    @classmethod
+    def id(cls):
+        return cls.user and cls.user.attributes["id"]
 
 
 class User(Model):
@@ -42,6 +45,11 @@ class User(Model):
 
     def _password_matches(self, password):
         return check_password_hash(self.attributes["password"], password)
+
+    @classmethod
+    def can_delete_quesiton(cls, question):
+        user_id = Auth.id()
+        return user_id and user_id == question.get_attribute("user_id")
 
     @classmethod
     def auth(cls):

--- a/api/core/error_handler.py
+++ b/api/core/error_handler.py
@@ -1,5 +1,5 @@
 from flask import jsonify
-from jwt.exceptions import ExpiredSignatureError
+from jwt.exceptions import ExpiredSignatureError, DecodeError
 
 errors = [
 
@@ -41,7 +41,13 @@ def token_expired(e):
     return jsonify({"error": "Token has expired"}), 401
 
 
+def error_token(e):
+    return jsonify({"error": "Error decoding token"}), 401
+
+
 def handle_errors(app):
     app.register_error_handler(ExpiredSignatureError, token_expired)
+    app.register_error_handler(DecodeError, error_token)
+
     for error in errors:
         _register_error_handler(app, error)

--- a/api/core/models/Model.py
+++ b/api/core/models/Model.py
@@ -116,6 +116,9 @@ class Model(ModelEvents):
 
         return ModelCollection(models)
 
+    def get_attribute(self, name):
+        return self.attributes.get(name)
+
     def __repr__(self):
         return str(self.attributes)
 

--- a/tests/feature/__init__.py
+++ b/tests/feature/__init__.py
@@ -45,12 +45,19 @@ class BaseTestCase(TestCase):
         return options
 
     def with_authentication(self):
-        user = dict(
-            name="Ahimbisibwe Roland",
-            email="rolandmbasa@gmail.com",
-            password="password",
-            password_confirmation="password"
-        )
+        self.login()
+
+    def login(self, user=None):
+        if not user:
+            user = dict(
+                name="Ahimbisibwe Roland",
+                email="rolandmbasa@gmail.com",
+
+            )
+
+        user["password"] = "password"
+        user["password_confirmation"] = "password"
+
         rv = self.post("/auth/signup", user)
         # ensure registration passed since Flask doesn't handle errors
         # during testing

--- a/tests/feature/test_Questions.py
+++ b/tests/feature/test_Questions.py
@@ -48,6 +48,16 @@ class TestQuestions(BaseTestCase):
         rv = self.delete("/questions/1")
         self.assertEqual(rv.status_code, 200)
 
+    def test_returns_a_401_response_when_deleting_others_question(self):
+        self.post("/questions", self.question)
+        user = dict({
+            "name": "Ahimbisibwe Roland",
+            "email": "lonusroland@gmail.com",
+        })
+        self.login(user)
+        rv = self.delete("/questions/1")
+        self.assertEqual(rv.status_code, 401)
+
     def test_it_returns_a_404_status_code_when_deleting_an_non_id(self):
         rv = self.delete("/questions/1")
         self.assertEqual(rv.status_code, 404)


### PR DESCRIPTION
#### What does this PR do?
Currently, any authenticated user can delete a question irrespective of who created it. This PR ensures that a question can only be deleted by a user who created it
#### Description of Task to be completed?
- Deny access to end point `DELETE /questions/id` for users who doint own the question 
#### How should this be manually tested?
- Refer to the `README.md` for setup instructions
- While the app is running, create two users using post man by hitting the endpoint `POST auth/signup` .
- Login in using the first user  by hitting the endpoint `POST auth/login`
- Add the returned token to headers with  `key:Authorization` and ` value: BEARER  {token_generated}`
- Create A question by hitting the route  `POST /questions` with `title` and `description` fields
- Using the same methods a bove create a second user and add the Authorization header respectively
- Making a  post request  `questions/id` where id is the id of the question that was created above should return `Access Denied for deleting question`
- You can also trigger the related test by running `pytest -k  pytest -k test_returns_a_401_response_when_deleting_others_question`


#### What are the relevant pivotal tracker stories?
[#160057897](https://www.pivotaltracker.com/story/show/160057897)
