### PR TITLE
##4058942 Add User Access Control list to  Access Control Entries

### DIFF
--- a/api/app/controllers/AnswersController.py
+++ b/api/app/controllers/AnswersController.py
@@ -1,5 +1,5 @@
 from flask import jsonify, request
-from api.app.models import Question, Answer
+from api.app.models import Question, Answer, User
 from .BaseController import ProtectedController
 
 
@@ -33,5 +33,8 @@ class AnswersController(ProtectedController):
 
     @classmethod
     def destroy(cls, question_id, answer_id):
-        Answer.by_question_id(question_id, answer_id).delete()
+        answer = Answer(Answer.where(id=answer_id).first_or_fail())
+        if not User.owns_answer(answer):
+            return jsonify(dict(error="Access denied")), 401
+        answer.delete()
         return jsonify(dict(message="Answer was successively removed")), 200

--- a/api/app/controllers/AnswersController.py
+++ b/api/app/controllers/AnswersController.py
@@ -24,16 +24,15 @@ class AnswersController(ProtectedController):
 
     @classmethod
     def update(cls, question_id, answer_id):
-        answer = Answer.find_or_fail(answer_id).update(
-            request.validate({
-                "body": "required"
-            }))
-
-        return jsonify(dict(data=answer)), 200
+        answer = Answer.find_or_fail(answer_id)
+        if User.owns_answer(answer):
+            answer.update(request.validate({"body": "required"}))
+            return jsonify(dict(data=answer)), 200
+        return jsonify(dict(error="Access denied for updating answer")), 401
 
     @classmethod
     def destroy(cls, question_id, answer_id):
-        answer = Answer(Answer.where(id=answer_id).first_or_fail())
+        answer = Answer.find_or_fail(answer_id)
         if not User.owns_answer(answer):
             return jsonify(dict(error="Access denied")), 401
         answer.delete()

--- a/api/app/controllers/QuestionsController.py
+++ b/api/app/controllers/QuestionsController.py
@@ -29,8 +29,14 @@ class QuestionsController(ProtectedController):
 
     @classmethod
     def update(cls, id):
+        question = Question.find_or_fail(id)
+        if not User.owns_question(question):
+            return jsonify({
+                "error": "Access denied for updating question"
+            }), 401
+
         return jsonify({
-            "data": Question.find_or_fail(id).update(
+            "data": question.update(
                 request.validate(validation_rules)
             )
         })
@@ -38,7 +44,7 @@ class QuestionsController(ProtectedController):
     @classmethod
     def destroy(cls, id):
         question = Question.find_or_fail(id)
-        if not User.can_delete_quesiton(question):
+        if not User.owns_question(question):
             return jsonify(dict(
                 error="Access denied  to delete question"
             )), 401

--- a/api/app/controllers/QuestionsController.py
+++ b/api/app/controllers/QuestionsController.py
@@ -1,5 +1,5 @@
 from flask import jsonify, request
-from api.app.models import Question
+from api.app.models import Question, User
 from .BaseController import ProtectedController
 
 validation_rules = {
@@ -37,5 +37,10 @@ class QuestionsController(ProtectedController):
 
     @classmethod
     def destroy(cls, id):
-        Question.find_or_fail(id).delete()
+        question = Question.find_or_fail(id)
+        if not User.can_delete_quesiton(question):
+            return jsonify(dict(
+                error="Access denied  to delete question"
+            )), 401
+        question.delete()
         return jsonify(dict(message="Resource was removed successfully"))

--- a/api/app/databases/migrations/Questions.py
+++ b/api/app/databases/migrations/Questions.py
@@ -21,6 +21,7 @@ class AnswersTable(Migration):
         table.increments("id")
         table.text("body")
         table.integer("question_id")
+        table.integer("user_id")
         table.timestamps()
 
     def down(self):

--- a/api/app/databases/migrations/Questions.py
+++ b/api/app/databases/migrations/Questions.py
@@ -6,6 +6,7 @@ class QuestionsTable(Migration):
     def up(self):
         table = TableSchema.create("questions")
         table.increments("id")
+        table.integer("user_id")
         table.string("title", 100)
         table.text("description")
         table.timestamps()

--- a/api/app/models/Answer.py
+++ b/api/app/models/Answer.py
@@ -1,4 +1,5 @@
 from api.core.models import Model
+from .User import Auth
 
 
 class Answer(Model):
@@ -9,3 +10,6 @@ class Answer(Model):
     @classmethod
     def by_question_id(cls, qtn_id, ans_id):
         return cls.where(question_id=qtn_id, id=ans_id)
+
+    def _creating(self):
+        self.attributes["user_id"] = Auth.id()

--- a/api/app/models/Question.py
+++ b/api/app/models/Question.py
@@ -1,5 +1,6 @@
 from api.core.models import Model
 from .Answer import Answer
+from .User import Auth
 
 
 class Question(Model):
@@ -9,3 +10,6 @@ class Question(Model):
 
     def answers(self):
         return self.has_many(Answer)
+
+    def _creating(self):
+        self.attributes["user_id"] = Auth.id()

--- a/api/app/models/User.py
+++ b/api/app/models/User.py
@@ -18,8 +18,7 @@ class Auth:
         return self.jwt.generate_token(user.attributes["email"])
 
     def is_authenticated(self):
-        if not self.user:
-            self.user = self.get_user(self.jwt.get_subject_from_headers())
+        Auth.user = self.get_user(self.jwt.get_subject_from_headers())
         return True
 
     def get_user(self, email):
@@ -27,6 +26,10 @@ class Auth:
         if not data:
             return abort(401, "Email Address not found")
         return self.UserModel(data)
+
+    @classmethod
+    def id(cls):
+        return cls.user and cls.user.attributes["id"]
 
 
 class User(Model):
@@ -42,6 +45,11 @@ class User(Model):
 
     def _password_matches(self, password):
         return check_password_hash(self.attributes["password"], password)
+
+    @classmethod
+    def can_delete_quesiton(cls, question):
+        user_id = Auth.id()
+        return user_id and user_id == question.get_attribute("user_id")
 
     @classmethod
     def auth(cls):

--- a/api/app/models/User.py
+++ b/api/app/models/User.py
@@ -29,7 +29,9 @@ class Auth:
 
     @classmethod
     def id(cls):
-        return cls.user and cls.user.attributes["id"]
+        if cls.user:
+            return cls.user.attributes["id"]
+        abort(401, "User is not signed in")
 
 
 class User(Model):
@@ -48,8 +50,16 @@ class User(Model):
 
     @classmethod
     def owns_question(cls, question):
+        return cls.entity_belongs_to_user(question)
+
+    @classmethod
+    def owns_answer(cls, answer):
+        return cls.entity_belongs_to_user(answer)
+
+    @classmethod
+    def entity_belongs_to_user(cls, entity, attribute="user_id"):
         user_id = Auth.id()
-        return user_id and user_id == question.get_attribute("user_id")
+        return user_id and user_id == entity.get_attribute(attribute)
 
     @classmethod
     def auth(cls):

--- a/api/app/models/User.py
+++ b/api/app/models/User.py
@@ -58,8 +58,7 @@ class User(Model):
 
     @classmethod
     def entity_belongs_to_user(cls, entity, attribute="user_id"):
-        user_id = Auth.id()
-        return user_id and user_id == entity.get_attribute(attribute)
+        return Auth.id() == entity.get_attribute(attribute)
 
     @classmethod
     def auth(cls):

--- a/api/app/models/User.py
+++ b/api/app/models/User.py
@@ -31,7 +31,7 @@ class Auth:
     def id(cls):
         if cls.user:
             return cls.user.attributes["id"]
-        abort(401, "User is not signed in")
+        abort(401, "User is not signed in")  # pragma: no cover
 
 
 class User(Model):

--- a/api/app/models/User.py
+++ b/api/app/models/User.py
@@ -47,7 +47,7 @@ class User(Model):
         return check_password_hash(self.attributes["password"], password)
 
     @classmethod
-    def can_delete_quesiton(cls, question):
+    def owns_question(cls, question):
         user_id = Auth.id()
         return user_id and user_id == question.get_attribute("user_id")
 

--- a/api/core/error_handler.py
+++ b/api/core/error_handler.py
@@ -1,5 +1,5 @@
 from flask import jsonify
-from jwt.exceptions import ExpiredSignatureError
+from jwt.exceptions import ExpiredSignatureError, DecodeError
 
 errors = [
 
@@ -41,7 +41,13 @@ def token_expired(e):
     return jsonify({"error": "Token has expired"}), 401
 
 
+def error_token(e):
+    return jsonify({"error": "Error decoding token"}), 401
+
+
 def handle_errors(app):
     app.register_error_handler(ExpiredSignatureError, token_expired)
+    app.register_error_handler(DecodeError, error_token)
+
     for error in errors:
         _register_error_handler(app, error)

--- a/api/core/models/Model.py
+++ b/api/core/models/Model.py
@@ -116,6 +116,9 @@ class Model(ModelEvents):
 
         return ModelCollection(models)
 
+    def get_attribute(self, name):
+        return self.attributes.get(name)
+
     def __repr__(self):
         return str(self.attributes)
 

--- a/tests/feature/__init__.py
+++ b/tests/feature/__init__.py
@@ -11,6 +11,14 @@ class BaseTestCase(TestCase):
         self.url_prefix = "api"
         self.api_version = "v1.0"
         self.auth_token = None
+        self.user_one = dict({
+            "name": "Ahimbisibwe Roland",
+            "email": "lonusroland@gmail.com",
+        })
+        self.user_two = dict({
+            "name": "Nabaasa Richard",
+            "email": "nabrick@gmail.com",
+        })
         with self.app.app_context():
             migrate()
 
@@ -49,11 +57,7 @@ class BaseTestCase(TestCase):
 
     def login(self, user=None):
         if not user:
-            user = dict(
-                name="Ahimbisibwe Roland",
-                email="rolandmbasa@gmail.com",
-
-            )
+            user = self.user_one
 
         user["password"] = "password"
         user["password_confirmation"] = "password"

--- a/tests/feature/__init__.py
+++ b/tests/feature/__init__.py
@@ -45,12 +45,19 @@ class BaseTestCase(TestCase):
         return options
 
     def with_authentication(self):
-        user = dict(
-            name="Ahimbisibwe Roland",
-            email="rolandmbasa@gmail.com",
-            password="password",
-            password_confirmation="password"
-        )
+        self.login()
+
+    def login(self, user=None):
+        if not user:
+            user = dict(
+                name="Ahimbisibwe Roland",
+                email="rolandmbasa@gmail.com",
+
+            )
+
+        user["password"] = "password"
+        user["password_confirmation"] = "password"
+
         rv = self.post("/auth/signup", user)
         # ensure registration passed since Flask doesn't handle errors
         # during testing

--- a/tests/feature/test_QuestionAnswers.py
+++ b/tests/feature/test_QuestionAnswers.py
@@ -56,6 +56,13 @@ class TestQuestionAnswers(BaseTestCase):
         answer = rv.get_json()["data"]
         self.assertDictContainsSubset(update, answer)
 
+    def test_it_fails_updating_another_users_answer(self):
+        self.post(self.answers_url(), dict(body="Some existing answer"))
+        self.login(self.user_two)
+        update = dict(body="Updated answer")
+        rv = self.put(self.answer_url(1), update)
+        self.assertEqual(rv.status_code, 401)
+
     def test_it_deletes_an_existing_question(self):
         self.post(self.answers_url(), dict(body="Some existing answer"))
         self.delete(self.answer_url(1))

--- a/tests/feature/test_QuestionAnswers.py
+++ b/tests/feature/test_QuestionAnswers.py
@@ -43,6 +43,12 @@ class TestQuestionAnswers(BaseTestCase):
         rv = self.get(self.answer_url(1))
         self.assertEqual(rv.status_code, 200)
 
+    def test_user_cannot_delete_other_users_answer(self):
+        self.post(self.answers_url(), dict(body="Some existing answer"))
+        self.login(self.user_two)
+        rv = self.delete(self.answer_url(1))
+        self.assertEqual(rv.status_code, 401)
+
     def test_it_updates_an_existing_question_answer(self):
         self.post(self.answers_url(), dict(body="Some existing answer"))
         update = dict(body="Updated answer")

--- a/tests/feature/test_Questions.py
+++ b/tests/feature/test_Questions.py
@@ -48,6 +48,16 @@ class TestQuestions(BaseTestCase):
         rv = self.delete("/questions/1")
         self.assertEqual(rv.status_code, 200)
 
+    def test_returns_a_401_response_when_deleting_others_question(self):
+        self.post("/questions", self.question)
+        user = dict({
+            "name": "Ahimbisibwe Roland",
+            "email": "lonusroland@gmail.com",
+        })
+        self.login(user)
+        rv = self.delete("/questions/1")
+        self.assertEqual(rv.status_code, 401)
+
     def test_it_returns_a_404_status_code_when_deleting_an_non_id(self):
         rv = self.delete("/questions/1")
         self.assertEqual(rv.status_code, 404)

--- a/tests/feature/test_Questions.py
+++ b/tests/feature/test_Questions.py
@@ -48,16 +48,6 @@ class TestQuestions(BaseTestCase):
         rv = self.delete("/questions/1")
         self.assertEqual(rv.status_code, 200)
 
-    def test_returns_a_401_response_when_deleting_others_question(self):
-        self.post("/questions", self.question)
-        user = dict({
-            "name": "Ahimbisibwe Roland",
-            "email": "lonusroland@gmail.com",
-        })
-        self.login(user)
-        rv = self.delete("/questions/1")
-        self.assertEqual(rv.status_code, 401)
-
     def test_it_returns_a_404_status_code_when_deleting_an_non_id(self):
         rv = self.delete("/questions/1")
         self.assertEqual(rv.status_code, 404)
@@ -70,3 +60,17 @@ class TestQuestions(BaseTestCase):
         self.assertEqual(rv.status_code, 200)
         data = rv.get_json()["data"]
         self.assertEqual(data["title"], self.question["title"])
+
+    def test_returns_a_401_response_when_deleting_others_question(self):
+        self.post("/questions", self.question)
+        self.login(self.user_two)
+        rv = self.delete("/questions/1")
+        self.assertEqual(rv.status_code, 401)
+
+    def test_returns_a_401_when_updating_others_users_question(self):
+        self.post("/questions", self.question)
+        self.login(self.user_two)
+        update = dict(title="Updated title", description="Updated description")
+        self.question.update(update)
+        rv = self.patch("/questions/1", update)
+        self.assertEqual(rv.status_code, 401)


### PR DESCRIPTION
#### What does this PR do?
Currently, any authenticated user is allowed to modify or tamper with Access Control Entries that belong to other users, say a user can update some other user's question. This PR ensures that only Authors can modify their own entries (Access Control List)
#### Description of Task to be completed?
- Deny access to modification endpoints of resources that belong to other users
#### How should this be manually tested?
- Refer to the `README.md` for setup instructions
- While the app is running, create two users using post man by hitting the endpoint `POST auth/signup`.
- Log in using the first user  by hitting the endpoint `POST auth/login`
- Add the returned token to headers with  `key:Authorization` and ` value: BEARER  {token_generated}`
- Create A question by hitting the route  `POST /questions` with `title` and `description` fields
- Using the same methods above create a second user and add the Authorization header respectively
- While logged in as the second user, try to hit endpoint that either updates or deletes the question above
- Both endpoints should fail
- Repeat the above steps for answer endpoints and they should also fail
- You can also trigger the related test by running `pytest`
#### Any background context you want to provide?
https://docs.microsoft.com/en-us/windows/desktop/secauthz/access-control-lists

#### What are the relevant pivotal tracker stories?
- [#160057897](https://www.pivotaltracker.com/story/show/160057897)
- [#160072469](https://www.pivotaltracker.com/story/show/160072469)
- [#160082969](https://www.pivotaltracker.com/story/show/160082969)
- [#160082607](https://www.pivotaltracker.com/story/show/160082607)